### PR TITLE
fix incorrect type definition: wrapClassName should be a string, not a boolean.

### DIFF
--- a/src/components/Modal/Modal.d.ts
+++ b/src/components/Modal/Modal.d.ts
@@ -24,7 +24,7 @@ declare class MDBModal extends React.Component<
     size?: 'sm' | 'md' | 'lg' | 'fluid';
     role?: string;
     tabIndex?: string;
-    wrapClassName?: boolean;
+    wrapClassName?: string;
     keyboard?: boolean;
     toggle?: () => void;
     hiddenModal?: () => void;


### PR DESCRIPTION
In Modal component: wrapClassName should be a string, not a boolean.